### PR TITLE
Add 'title' attribute; bump to 0.1.3 version

### DIFF
--- a/lib/Cell.jsx
+++ b/lib/Cell.jsx
@@ -9,7 +9,8 @@ const Cell = React.createClass({
             React.PropTypes.element,
             React.PropTypes.string,
             React.PropTypes.number
-        ])
+        ]),
+        title: React.PropTypes.string
     },
     shouldComponentUpdate: function(nextProps) {
         if (nextProps.width !== this.props.width) {
@@ -44,7 +45,7 @@ const Cell = React.createClass({
         };
 
         return (
-            <div className={this.getClassName()} style={styles.col}>
+            <div className={this.getClassName()} title={this.props.title} style={styles.col}>
                 {this.props.label}
             </div>
         );

--- a/lib/ColumnHeader.jsx
+++ b/lib/ColumnHeader.jsx
@@ -5,11 +5,13 @@ const ColumnHeader = React.createClass({
     displayName: 'ColumnHeader',
     propTypes: {
         label: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.element]),
-        width: React.PropTypes.number.isRequired
+        width: React.PropTypes.number.isRequired,
+        title: React.PropTypes.string
     },
     getDefaultProps() {
         return {
-            label: ''
+            label: '',
+            title: ''
         };
     },
     shouldComponentUpdate(nextProps) {
@@ -24,12 +26,12 @@ const ColumnHeader = React.createClass({
     },
     render() {
         return (
-            <Cell className="supertable-columnHeader" width={this.props.width} label={this.renderLabel()} />
+            <Cell className="supertable-columnHeader" width={this.props.width} label={this.renderLabel()} title={this.props.title} />
         );
     },
     renderLabel() {
         return (
-            <div>
+            <div title={this.props.title}>
                 {this.props.label}
             </div>
         );

--- a/lib/__tests__/Cell-test.js
+++ b/lib/__tests__/Cell-test.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const TestUtils = React.addons.TestUtils;
+const TestUtils = require('react-addons-test-utils');
 
 const Cell = require('../Cell.jsx');
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "peerDependencies": {
     "react": "^0.14.2",
     "react-addons-pure-render-mixin": "^0.14.2",
-    "react-addons-css-transition-group": "^0.14.2"
+    "react-addons-css-transition-group": "^0.14.2",
+    "react-addons-test-utils": "^0.14.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supertable",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "React table component",
   "main": "supertable.js",
   "scripts": {


### PR DESCRIPTION
This adds a 'title' attribute to cell & column header components.
Which can be used to hook into re: tooltips and other add ons.
